### PR TITLE
fix(windows): prevent terminal flash and fix focus stealing on Ctrl+C…

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -247,7 +247,6 @@ impl ShortcutAction for SpeakAction {
         };
 
         speech.initiate_model_load();
-        show_processing_overlay(app);
         let app_handle = app.clone();
         std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(SHORTCUT_SETTLE_DELAY_MS));
@@ -257,6 +256,11 @@ impl ShortcutAction for SpeakAction {
                     if !speech.is_request_active(request_id) {
                         return;
                     }
+                    // Show overlay only after grabbing text — showing it before
+                    // the copy causes WM_ACTIVATE to steal focus from the source
+                    // app on Windows, so the injected Ctrl+C lands in the overlay
+                    // instead of the text the user had selected.
+                    show_processing_overlay(&app_handle);
                     debug!("Speaking {} chars via TTS", text.len());
                     speech.speak(text, request_id);
                 }

--- a/src-tauri/src/input.rs
+++ b/src-tauri/src/input.rs
@@ -47,6 +47,16 @@ pub fn send_copy_ctrl_c(enigo: &mut Enigo) -> Result<(), String> {
 
 #[cfg(not(target_os = "macos"))]
 pub fn send_copy_ctrl_c(enigo: &mut Enigo) -> Result<(), String> {
+    // Release Shift/Alt/Meta that may still be held from the trigger shortcut.
+    // Without this, Ctrl+Shift+P leaves Shift held, turning the injected
+    // Ctrl+C into Ctrl+Shift+C (which opens Windows Terminal).
+    // Ctrl is intentionally NOT released here: releasing it while the user
+    // physically holds it causes a brief up/down cycle that stops the focused
+    // app from registering the copy, resulting in "please select text" errors.
+    let _ = enigo.key(Key::Shift, enigo::Direction::Release);
+    let _ = enigo.key(Key::Alt, enigo::Direction::Release);
+    let _ = enigo.key(Key::Meta, enigo::Direction::Release);
+
     enigo
         .key(Key::Control, enigo::Direction::Press)
         .map_err(|e| format!("Failed to press Ctrl key: {}", e))?;


### PR DESCRIPTION
fix(windows): prevent terminal flash and fix focus stealing on Ctrl+C copy

---

## Before Submitting This PR

- [x] Searched existing issues and pull requests
- [x] Read CONTRIBUTING.md

---

## Human Written Description

Fixes two related bugs that occur on Windows when using a Ctrl+Shift trigger shortcut (e.g. Ctrl+Shift+P). When the shortcut fires, Shift remains held in the OS key table, causing the injected Ctrl+C to become Ctrl+Shift+C — which opens a new Windows Terminal tab on every invocation. Additionally, showing the processing overlay before the copy completes fires WM_ACTIVATE, stealing focus from the source app so the injected keystroke lands in the overlay instead of the selected text.

The fix releases Shift, Alt, and Meta before injecting the copy keystroke, and defers showing the overlay until after the text is successfully retrieved.

I noticed you already have a branch (`vk/96b7-windows-issue`) working on this issue — looks like yours tackles the espeak-ng console windows side, while this PR addresses the key injection side. Happy to adjust, combine, or close this in favour of your branch if you'd prefer. Just wanted to share what I found in case any of it is useful.

---

## Related Issues/Discussions

Fixes #7  
Discussion: N/A

---

## Community Feedback

N/A

---

## Testing

Tested on Windows 11 with shortcut set to Ctrl+Shift+P in:
- Chrome (text selected in browser)
- Notepad
- Windows Terminal

No terminal windows flash. No "please select text" errors on first use.

---

## Screenshots/Videos (if applicable)

N/A

---

## AI Assistance

- [x] AI was used (please describe below)

**Tools used:** Claude Sonnet 4.6 (Claude Code)  
**How extensively:** Assisted with root cause analysis, drafting the fix description, and code implementation; tested and verified by human on Windows 11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech hotkey behavior: processing overlay now appears only after text is successfully selected.
  * Fixed copy command on Windows and Linux to prevent unintended keyboard shortcut modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->